### PR TITLE
feat: support display-override notes for commit history

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/configure-pages@v4
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Fetch display-override notes
+        run: git fetch origin refs/notes/site-display:refs/notes/site-display || echo "No notes ref on origin yet"
       - name: Generate commits data
         run: |
           python3 scripts/generate-commits-data.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,4 @@ Route out when: life/work prioritization decisions → `../AGENTS.md` then `../b
 - Keep markdown clean and copy-edit for scanability.
 - When touching publishing flow, run the smallest relevant verification step first.
 - If uncertain about intent or substitutions in a recipe, preserve user-authored meaning and ask before changing culinary details.
+- Git notes (`refs/notes/site-display`, used to correct a commit's displayed heading/body without rewriting history — see README) are NOT included in a normal `git push`/`fetch`/`clone`. After `make note`, run `make notes-push` to publish it; run `make notes-sync` to pull down notes made elsewhere.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 HUGO_VERSION := 0.122.0
+NOTES_REF := refs/notes/site-display
 
 help:           ## Show this help.
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
@@ -14,6 +15,20 @@ build: .bin/hugo generate-commits   ## Build the site
 .phony: generate-commits
 generate-commits:   ## Generate commits data for home page
 	uv run scripts/generate-commits-data.py
+
+.phony: note
+note:   ## Add/edit a display-override note for a commit: make note HASH=<commit-hash>
+	@test -n "$(HASH)" || (echo "Usage: make note HASH=<commit-hash>"; exit 1)
+	@git notes --ref=$(NOTES_REF) edit $(HASH)
+	@echo "Note saved locally. Run 'make notes-push' to publish it."
+
+.phony: notes-push
+notes-push:   ## Publish local display-override notes to origin
+	@git push origin $(NOTES_REF)
+
+.phony: notes-sync
+notes-sync:   ## Fetch display-override notes from origin
+	@git fetch origin $(NOTES_REF):$(NOTES_REF)
 
 .phony: smoke-check
 smoke-check: ## Run lightweight repository smoke checks

--- a/Makefile
+++ b/Makefile
@@ -4,33 +4,33 @@ NOTES_REF := refs/notes/site-display
 help:           ## Show this help.
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
-.phony: run
+.PHONY: run
 run: .bin/hugo generate-commits   ## Run site
 	@.bin/hugo serve
 
-.phony: build
+.PHONY: build
 build: .bin/hugo generate-commits   ## Build the site
 	@.bin/hugo
 
-.phony: generate-commits
+.PHONY: generate-commits
 generate-commits:   ## Generate commits data for home page
 	uv run scripts/generate-commits-data.py
 
-.phony: note
+.PHONY: note
 note:   ## Add/edit a display-override note for a commit: make note HASH=<commit-hash>
 	@test -n "$(HASH)" || (echo "Usage: make note HASH=<commit-hash>"; exit 1)
 	@git notes --ref=$(NOTES_REF) edit $(HASH)
 	@echo "Note saved locally. Run 'make notes-push' to publish it."
 
-.phony: notes-push
+.PHONY: notes-push
 notes-push:   ## Publish local display-override notes to origin
 	@git push origin $(NOTES_REF)
 
-.phony: notes-sync
+.PHONY: notes-sync
 notes-sync:   ## Fetch display-override notes from origin
 	@git fetch origin $(NOTES_REF):$(NOTES_REF)
 
-.phony: smoke-check
+.PHONY: smoke-check
 smoke-check: ## Run lightweight repository smoke checks
 	@test -f AGENTS.md
 	@test -f README.md
@@ -40,7 +40,7 @@ smoke-check: ## Run lightweight repository smoke checks
 	@git status -s >/dev/null
 	@echo "recipe smoke checks passed"
 
-.phony: newcontent
+.PHONY: newcontent
 # TODO, actually implement base on parameter?
 # hugo new content recipe/kamala-tuna-melt.md
 # OR
@@ -48,7 +48,7 @@ smoke-check: ## Run lightweight repository smoke checks
 # and can auto-open in codespaces with
 # `code <filename>`
 
-.phony: newsite
+.PHONY: newsite
 newsite: .bin/hugo  ## New hugo site - only used once
 	@.bin/hugo new site . --force --format yaml
 	@find . -maxdepth 1 -type d -not -name '.*' | while read dir; do touch $${dir}/.gitkeep; done

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,17 @@ generate-commits:   ## Generate commits data for home page
 	uv run scripts/generate-commits-data.py
 
 .PHONY: note
-note:   ## Add/edit a display-override note for a commit: make note HASH=<commit-hash>
+note:   ## Add/edit a display-override note: make note HASH=<hash> (local only - git push does NOT push notes, run notes-push after)
 	@test -n "$(HASH)" || (echo "Usage: make note HASH=<commit-hash>"; exit 1)
 	@git notes --ref=$(NOTES_REF) edit $(HASH)
 	@echo "Note saved locally. Run 'make notes-push' to publish it."
 
 .PHONY: notes-push
-notes-push:   ## Publish local display-override notes to origin
+notes-push:   ## Push refs/notes/site-display to origin (required after 'make note' - not included in a normal git push)
 	@git push origin $(NOTES_REF)
 
 .PHONY: notes-sync
-notes-sync:   ## Fetch display-override notes from origin
+notes-sync:   ## Pull refs/notes/site-display from origin (not included in a normal git fetch/pull/clone)
 	@git fetch origin $(NOTES_REF):$(NOTES_REF)
 
 .PHONY: smoke-check

--- a/README.md
+++ b/README.md
@@ -2,4 +2,33 @@
 
 Family Recipes, in a static site.
 
+## Local Build
+
+```sh
+make build   # Generate commits data and build the site
+make run     # Generate commits data and serve locally
+```
+
+## Correcting a commit's displayed text
+
+The homepage renders git commit messages directly (see `scripts/generate-commits-data.py`),
+so a typo or unclear message would otherwise be permanent-looking without
+editing history. Instead, attach a "display override" note — it doesn't
+touch the commit or its hash, so no history rewrite or force-push is needed:
+
+```sh
+make note HASH=<commit-hash>   # opens $EDITOR: first line = heading,
+                                # blank line, then body text
+make notes-push                # publish the note to origin
+```
+
+A commit with no note shows its real message, unchanged. To remove an
+override: `git notes --ref=refs/notes/site-display remove <commit-hash>`.
+
+Notes live under `refs/notes/site-display` and aren't fetched by a normal
+`git pull`/clone, so pull down anyone else's notes with:
+
+```sh
+make notes-sync
+```
 

--- a/scripts/generate-commits-data.py
+++ b/scripts/generate-commits-data.py
@@ -90,8 +90,17 @@ def get_note_overrides(notes_ref: str = NOTES_REF) -> dict[str, tuple[str, str]]
     commit's displayed subject/body be corrected without rewriting the
     commit itself. If a commit has no note, its real subject/body is used.
     """
-    # Exits 0 with empty output if the ref doesn't exist locally yet, so no
-    # special-casing is needed for a repo/clone with no notes.
+    # Check the ref exists first rather than relying on `git notes list`'s
+    # exit behavior for a missing ref, which isn't consistent across git
+    # versions/platforms — this way a fresh clone/CI checkout with no notes
+    # yet never risks a hard failure here.
+    ref_exists = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", notes_ref],
+        capture_output=True
+    ).returncode == 0
+    if not ref_exists:
+        return {}
+
     list_output = run_git_command(["notes", f"--ref={notes_ref}", "list"])
 
     overrides = {}

--- a/scripts/generate-commits-data.py
+++ b/scripts/generate-commits-data.py
@@ -22,8 +22,26 @@ The script will:
 1. Extract git commits (optionally filtered to content/ directory)
 2. Generate data/commits.json with commit details
 3. Map changed files to site URLs for linking
+4. Apply any display-override git notes (see NOTES_REF below) in place of
+   the real commit subject/body, without touching git history
 
-Shared with: https://github.com/ssmiller25/r15cookie-site
+Display overrides via git notes:
+    A commit's displayed heading/body can be corrected after the fact by
+    attaching a note under NOTES_REF, instead of rewriting history:
+
+        git notes --ref=refs/notes/site-display add -m "New heading
+
+        New body text." <commit-hash>
+        git push origin refs/notes/site-display
+
+    Notes aren't fetched by a normal `git fetch`/clone, so pull them
+    explicitly before generating data:
+
+        git fetch origin refs/notes/site-display:refs/notes/site-display
+
+    A commit with no note uses its real subject/body, unchanged.
+
+Based on: https://github.com/ssmiller25/r15cookie-site
 """
 
 import json
@@ -31,6 +49,11 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+
+# Notes ref used for display-override annotations. Kept separate from the
+# default refs/notes/commits so this concern doesn't collide with any other
+# use of git notes.
+NOTES_REF = "refs/notes/site-display"
 
 STATUS_MAP = {
     "A": {"label": "Added", "icon": "➕"},
@@ -60,8 +83,36 @@ def run_git_command(args: list[str], cwd: Path = None) -> str:
             print(f"Git error: {e.stderr}", file=sys.stderr)
         sys.exit(1)
 
-def get_commits(limit: int = 100, content_only: bool = True) -> list[dict]:
+def get_note_overrides(notes_ref: str = NOTES_REF) -> dict[str, tuple[str, str]]:
+    """Read display-override notes: commit_hash -> (heading, body).
+
+    Notes are attached with `git notes --ref={notes_ref} add ...` and let a
+    commit's displayed subject/body be corrected without rewriting the
+    commit itself. If a commit has no note, its real subject/body is used.
+    """
+    # Exits 0 with empty output if the ref doesn't exist locally yet, so no
+    # special-casing is needed for a repo/clone with no notes.
+    list_output = run_git_command(["notes", f"--ref={notes_ref}", "list"])
+
+    overrides = {}
+    for line in list_output.split("\n"):
+        if not line.strip():
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        note_blob_sha, commit_sha = parts
+        note_text = run_git_command(["show", note_blob_sha])
+        note_lines = note_text.split("\n")
+        heading = note_lines[0].strip()
+        body = "\n".join(note_lines[1:]).strip()
+        overrides[commit_sha] = (heading, body)
+
+    return overrides
+
+def get_commits(limit: int = 100, content_only: bool = True, note_overrides: dict | None = None) -> list[dict]:
     """Get recent commits with their details."""
+    note_overrides = note_overrides or {}
     format_str = "%H%n%h%n%an%n%ae%n%ai%n%s%n%b%n---COMMIT_SEPARATOR---%n"
     
     # Filter to only commits that touch content/ directory
@@ -90,7 +141,12 @@ def get_commits(limit: int = 100, content_only: bool = True) -> list[dict]:
         author_date = lines[4]
         subject = lines[5]
         body = "\n".join(lines[6:]).strip() if len(lines) > 6 else ""
-        
+
+        # A display-override note fully replaces both heading and body for
+        # this commit; the underlying commit itself is untouched.
+        if full_hash in note_overrides:
+            subject, body = note_overrides[full_hash]
+
         # Get changed files for this commit
         # -M enables rename detection so renames arrive as a single "Rxxx\told\tnew"
         # line instead of being split into a separate Delete + Add.
@@ -200,8 +256,10 @@ def main():
     
     data_dir.mkdir(exist_ok=True)
     
-    # Get commits (filtered to content/ by default)
-    commits = get_commits(limit=100, content_only=True)
+    # Get commits (filtered to content/ by default), applying any
+    # display-override notes on top of the real commit messages
+    note_overrides = get_note_overrides()
+    commits = get_commits(limit=100, content_only=True, note_overrides=note_overrides)
     
     # Get GitHub repo from config (if available)
     github_repo = ""
@@ -233,6 +291,9 @@ def main():
         json.dump(commits, f, indent=2)
     
     print(f"Generated {len(commits)} commits data at {output_file}")
+    applied_overrides = sum(1 for c in commits if c["full_hash"] in note_overrides)
+    if applied_overrides:
+        print(f"Applied {applied_overrides} display-override note(s) from {NOTES_REF}")
     if len(commits) == 0:
         print("NOTE: No commits found that touch content/ directory.")
         print("To include all commits, edit this script and set content_only=False")


### PR DESCRIPTION
## Summary
Commit messages rendered on the homepage are otherwise permanent-looking without rewriting git history. This adds a non-destructive alternative: git notes.

## Changes
- `scripts/generate-commits-data.py`:
  - New `NOTES_REF = "refs/notes/site-display"` and `get_note_overrides()` — reads that ref once per run, mapping `commit_sha -> (heading, body)`
  - `get_commits()` applies the override when present (first line of the note = heading, rest = body); commits without a note render their real message unchanged
- `Makefile`: `make note HASH=<hash>` (opens `$EDITOR`), `make notes-push`, `make notes-sync`
- `.github/workflows/hugo.yaml`: fetches `refs/notes/site-display` before generating commit data, so the deployed site reflects pushed notes
- `README.md`: new "Local Build" + "Correcting a commit's displayed text" sections

## Testing
- Added a real note locally, ran the generator, confirmed `commits.json` reflected the override; removed the note, confirmed fallback to the real message
- Verified this branch is a clean single-commit diff against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)